### PR TITLE
Use `rustler_precompiled` for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches:
       - main
-      - ps-add-precompilation-support
     tags:
       - '*'
 

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -1,9 +1,15 @@
 defmodule Explorer.PolarsBackend.Native do
   @moduledoc false
 
-  use Rustler,
+  mix_config = Mix.Project.config()
+  version = mix_config[:version]
+  github_url = mix_config[:package][:links]["GitHub"]
+
+  use RustlerPrecompiled,
     otp_app: :explorer,
-    crate: :explorer
+    version: version,
+    base_url: "#{github_url}/releases/download/v#{version}",
+    force_build: System.get_env("EXPLORER_BUILD") in ["1", "true"]
 
   defstruct [:inner]
 

--- a/mix.exs
+++ b/mix.exs
@@ -58,11 +58,10 @@ defmodule Explorer.MixProject do
         "lib",
         "native",
         "datasets",
-        # "notebooks", should we include this one?
         "checksum-*.exs",
         "mix.exs",
         "README.md",
-        # "CHANGELOG.md",
+        "CHANGELOG.md",
         "LICENSE"
       ],
       licenses: ["MIT"],

--- a/mix.exs
+++ b/mix.exs
@@ -10,6 +10,7 @@ defmodule Explorer.MixProject do
       name: "Explorer",
       version: @version,
       elixir: "~> 1.12",
+      package: package(),
       deps: deps(),
       docs: docs()
     ]
@@ -26,7 +27,7 @@ defmodule Explorer.MixProject do
     [
       {:ex_doc, "~> 0.24", only: :dev, runtime: false},
       {:nx, "~> 0.1.0"},
-      {:rustler, "~> 0.23.0"},
+      {:rustler_precompiled, "~> 0.2"},
       {:table_rex, "~> 3.1.1"}
     ]
   end
@@ -48,6 +49,24 @@ defmodule Explorer.MixProject do
           Explorer.PolarsBackend
         ]
       ]
+    ]
+  end
+
+  defp package do
+    [
+      files: [
+        "lib",
+        "native",
+        "datasets",
+        # "notebooks", should we include this one?
+        "checksum-*.exs",
+        "mix.exs",
+        "README.md",
+        # "CHANGELOG.md",
+        "LICENSE"
+      ],
+      licenses: ["MIT"],
+      links: %{"GitHub" => @source_url}
     ]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -60,8 +60,6 @@ defmodule Explorer.MixProject do
         "datasets",
         "checksum-*.exs",
         "mix.exs",
-        "README.md",
-        "CHANGELOG.md",
         "LICENSE"
       ],
       licenses: ["MIT"],

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,5 @@
 %{
+  "castore": {:hex, :castore, "0.1.15", "dbb300827d5a3ec48f396ca0b77ad47058578927e9ebe792abd99fcbc3324326", [:mix], [], "hexpm", "c69379b907673c7e6eb229f09a0a09b60bb27cfb9625bcb82ea4c04ba82a8442"},
   "earmark_parser": {:hex, :earmark_parser, "1.4.13", "0c98163e7d04a15feb62000e1a891489feb29f3d10cb57d4f845c405852bbef8", [:mix], [], "hexpm", "d602c26af3a0af43d2f2645613f65841657ad6efc9f0e361c3b6c06b578214ba"},
   "ex_doc": {:hex, :ex_doc, "0.25.0", "4070a254664ee5495c2f7cce87c2f43064a8752f7976f2de4937b65871b05223", [:mix], [{:earmark_parser, "~> 1.4.0", [hex: :earmark_parser, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]}, {:makeup_erlang, "~> 0.1", [hex: :makeup_erlang, repo: "hexpm", optional: false]}], "hexpm", "2d90883bd4f3d826af0bde7fea733a4c20adba1c79158e2330f7465821c8949b"},
   "jason": {:hex, :jason, "1.3.0", "fa6b82a934feb176263ad2df0dbd91bf633d4a46ebfdffea0c8ae82953714946", [:mix], [{:decimal, "~> 1.0 or ~> 2.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "53fc1f51255390e0ec7e50f9cb41e751c260d065dcba2bf0d08dc51a4002c2ac"},
@@ -8,6 +9,7 @@
   "nimble_parsec": {:hex, :nimble_parsec, "1.1.0", "3a6fca1550363552e54c216debb6a9e95bd8d32348938e13de5eda962c0d7f89", [:mix], [], "hexpm", "08eb32d66b706e913ff748f11694b17981c0b04a33ef470e33e11b3d3ac8f54b"},
   "nx": {:hex, :nx, "0.1.0", "8f8a047dc0fd2b1798406edf828b43c46cca648b13c58fd5abd52285316b3d86", [:mix], [], "hexpm", "24ce6e184dc9c7b7c6c247923bfbe994101a7fe049bd3fd376b5b0512f787256"},
   "rustler": {:hex, :rustler, "0.23.0", "87162ffdf5a46b6aa03d624a77367070ff1263961ae35332c059225e136c4a87", [:mix], [{:jason, "~> 1.2", [hex: :jason, repo: "hexpm", optional: false]}, {:toml, "~> 0.5.2", [hex: :toml, repo: "hexpm", optional: false]}], "hexpm", "f5ab6f0ec564f5569009c0f5685b0e5b379fd72655e82a8dc5a3c24f9fdda36a"},
+  "rustler_precompiled": {:hex, :rustler_precompiled, "0.2.0", "8cb0fb2527d51de624e91b45e0a2b12c92e1cb614f8616f8dfc07c3d1180f48a", [:mix], [{:castore, "~> 0.1", [hex: :castore, repo: "hexpm", optional: false]}, {:rustler, "~> 0.23", [hex: :rustler, repo: "hexpm", optional: false]}], "hexpm", "583be3d480fa292770d45d4e20418ad81b6d9acd2bc42d8776e79f4a283cbae4"},
   "table_rex": {:hex, :table_rex, "3.1.1", "0c67164d1714b5e806d5067c1e96ff098ba7ae79413cc075973e17c38a587caa", [:mix], [], "hexpm", "678a23aba4d670419c23c17790f9dcd635a4a89022040df7d5d772cb21012490"},
   "toml": {:hex, :toml, "0.5.2", "e471388a8726d1ce51a6b32f864b8228a1eb8edc907a0edf2bb50eab9321b526", [:mix], [], "hexpm", "f1e3dabef71fb510d015fad18c0e05e7c57281001141504c6b69d94e99750a07"},
 }

--- a/native/explorer/Cargo.toml
+++ b/native/explorer/Cargo.toml
@@ -19,6 +19,7 @@ rand_pcg = "0.3.1"
 rustler = { git = "https://github.com/rusterlium/rustler" }
 thiserror = "1"
 
+# This is because when using GCC on Windows MiMalloc won´t compile
 [target.'cfg(not(all(windows, target_env = "gnu")))'.dependencies]
 mimalloc = { version = "*", default-features = false }
 

--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -1,3 +1,4 @@
+// MiMalloc won´t compile on Windows with the GCC compiler
 #[cfg(not(all(windows, target_env = "gnu")))]
 use mimalloc::MiMalloc;
 use rustler::{Env, Term};


### PR DESCRIPTION
It makes Explorer force the usage of precompiled NIFs when it's not in a
pre-release version. Therefore people don't need to have Rust installed.

Users still can force the build by setting the system env var:

    EXPLORER_BUILD=true mix compile --force

Or by setting an application env:

    config :rustler_precompiled, :force_build, explorer: true

This is related to https://github.com/elixir-nx/explorer/pull/122